### PR TITLE
Video background pause and fit

### DIFF
--- a/src/ui/main/mod.rs
+++ b/src/ui/main/mod.rs
@@ -185,6 +185,8 @@ impl SimpleComponent for App {
 
                         #[wrap(Some)]
                         set_paintable = &gtk::MediaFile::for_filename(crate::BACKGROUND_VIDEO_FILE.as_path()) {
+                            #[watch]
+                            set_playing: !model.kill_game_button,
                             set_loop: true,
 
                             connect_error_notify: |mstream| {


### PR DESCRIPTION
1. Switch to using `gtk::Picture` and `gtk::MediaFile` to display video background. This helps avoid letterboxing, although the cropping still doesn't quite match the background image and overlay.
2. Pause the video background while the game is running so that the video decoding doesn't put extra load on the GPU or CPU.