### PR TITLE
Make DX12 optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,8 +57,8 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anime-game-core"
-version = "1.39.2"
-source = "git+https://github.com/an-anime-team/anime-game-core?tag=1.39.2#b53ab7a16530cb3d0e7930832d2930aee45584b8"
+version = "1.39.3"
+source = "git+https://github.com/an-anime-team/anime-game-core?tag=1.39.3#f1f0a23a9a6a0d66635796a52f5ef4d1eae18d77"
 dependencies = [
  "anyhow",
  "bzip2 0.4.4",
@@ -82,8 +82,8 @@ dependencies = [
 
 [[package]]
 name = "anime-launcher-sdk"
-version = "1.36.5"
-source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.36.5#2a5fc903033b9e06a508f843c13518e850f160ee"
+version = "1.36.9"
+source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.36.9#fed8ff10dd869d5f567a889e40b9812776f08a84"
 dependencies = [
  "anime-game-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ glib-build-tools = "0.20"
 
 [dependencies.anime-launcher-sdk]
 git = "https://github.com/an-anime-team/anime-launcher-sdk"
-tag = "1.36.5"
+tag = "1.36.9"
 features = ["all", "zzz"]
 
 # path = "../anime-launcher-sdk" # ! for dev purposes only

--- a/src/ui/preferences/enhancements/mod.rs
+++ b/src/ui/preferences/enhancements/mod.rs
@@ -1,12 +1,9 @@
 use relm4::prelude::*;
 use adw::prelude::*;
-
 use anime_launcher_sdk::config::ConfigExt;
 use anime_launcher_sdk::zzz::config::Config;
 use anime_launcher_sdk::config::schema_blanks::prelude::*;
-
 use anime_launcher_sdk::is_available;
-
 use enum_ordinalize::Ordinalize;
 
 pub mod game;
@@ -18,7 +15,6 @@ use sandbox::*;
 use environment::*;
 
 use crate::*;
-
 use super::gamescope::*;
 use super::main::PreferencesAppMsg;
 
@@ -505,14 +501,12 @@ impl SimpleAsyncComponent for EnhancementsApp {
     async fn init(
         _init: Self::Init,
         root: Self::Root,
-        sender: AsyncComponentSender<Self>,
+        sender: AsyncComponentSender<Self>
     ) -> AsyncComponentParts<Self> {
         tracing::info!("Initializing enhancements settings");
 
         let model = Self {
-            gamescope: GamescopeApp::builder()
-                .launch(())
-                .detach(),
+            gamescope: GamescopeApp::builder().launch(()).detach(),
 
             game_page: GamePage::builder()
                 .launch(())
@@ -536,59 +530,75 @@ impl SimpleAsyncComponent for EnhancementsApp {
         let widgets = view_output!();
 
         if !is_wayland_available() {
-            widgets.winewayland_row.set_tooltip_text(Some(&tr!("winewayland-unavailable-tooltip")));
+            widgets
+                .winewayland_row
+                .set_tooltip_text(Some(&tr!("winewayland-unavailable-tooltip")));
         }
 
-        AsyncComponentParts { model, widgets }
+        AsyncComponentParts {
+            model,
+            widgets
+        }
     }
 
     async fn update(&mut self, msg: Self::Input, sender: AsyncComponentSender<Self>) {
         match msg {
             EnhancementsAppMsg::SetGamescopeParent => unsafe {
-                self.gamescope.widget().set_transient_for(super::main::PREFERENCES_WINDOW.as_ref());
-            }
+                self.gamescope
+                    .widget()
+                    .set_transient_for(super::main::PREFERENCES_WINDOW.as_ref());
+            },
 
             EnhancementsAppMsg::OpenGamescope => {
                 self.gamescope.widget().present();
             }
 
             EnhancementsAppMsg::OpenMainPage => unsafe {
-                PREFERENCES_WINDOW.as_ref()
+                PREFERENCES_WINDOW
+                    .as_ref()
                     .unwrap_unchecked()
                     .widget()
                     .pop_subpage();
-            }
+            },
 
             EnhancementsAppMsg::OpenGameSettingsPage => unsafe {
-                PREFERENCES_WINDOW.as_ref()
+                PREFERENCES_WINDOW
+                    .as_ref()
                     .unwrap_unchecked()
                     .widget()
                     .push_subpage(self.game_page.widget());
-            }
+            },
 
             EnhancementsAppMsg::OpenSandboxSettingsPage => unsafe {
-                PREFERENCES_WINDOW.as_ref()
+                PREFERENCES_WINDOW
+                    .as_ref()
                     .unwrap_unchecked()
                     .widget()
                     .push_subpage(self.sandbox_page.widget());
-            }
+            },
 
             EnhancementsAppMsg::OpenEnvironmentSettingsPage => unsafe {
-                PREFERENCES_WINDOW.as_ref()
+                PREFERENCES_WINDOW
+                    .as_ref()
                     .unwrap_unchecked()
                     .widget()
                     .push_subpage(self.environment_page.widget());
-            }
+            },
 
             EnhancementsAppMsg::SetTimeoutFix(value) => {
                 self.timeout_fix = value;
             }
 
-            EnhancementsAppMsg::Toast { title, description } => {
-                sender.output(PreferencesAppMsg::Toast {
-                    title,
-                    description
-                }).unwrap();
+            EnhancementsAppMsg::Toast {
+                title,
+                description
+            } => {
+                sender
+                    .output(PreferencesAppMsg::Toast {
+                        title,
+                        description
+                    })
+                    .unwrap();
             }
         }
     }

--- a/src/ui/preferences/enhancements/mod.rs
+++ b/src/ui/preferences/enhancements/mod.rs
@@ -65,12 +65,14 @@ impl SimpleAsyncComponent for EnhancementsApp {
 
                         set_active: CONFIG.game.enhancements.dx12,
 
-                        connect_state_notify => |switch| {
+                        connect_state_notify[sender] => move |switch| {
                             if is_ready() {
                                 if let Ok(mut config) = Config::get() {
                                     config.game.enhancements.dx12 = switch.is_active();
 
                                     Config::update(config);
+
+                                    let _ = sender.output(PreferencesAppMsg::UpdateLauncherState);
                                 }
                             }
                         }


### PR DESCRIPTION
Depends on https://github.com/an-anime-team/anime-launcher-sdk/pull/46 which contains the majority of the implementation

This PR adds triggering of launcher state re-evaluation when dx12 switch is toggled to prompt the user to install required libraries.

Tested locally on a fresh prefix